### PR TITLE
Added metrics to app-service for prometheus monitoring

### DIFF
--- a/app-service/requirements.txt
+++ b/app-service/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.1.0
 requests==2.32.3
 python-dotenv==1.0.1
 lib_version @ https://github.com/remla25-team4/lib-version/releases/download/v0.1.1/lib_version-0.1.1-py3-none-any.whl
+prometheus-flask-exporter==0.23.2


### PR DESCRIPTION
Added the following metrics to app-service using prometheus-flask-exporter:
- tracking libversion
- wrong_prediction_counter -> counts total number of wrong predictions and tracks what the actual prediction was as well as how long the review was.
- prediction_request_gauge -> amount of active prediction requests at the time
- failed_prediction_requests -> tracks how many prediction requests failed and whether the app service failed or the model service.