### PR TITLE
Solved the feedback reset issue

### DIFF
--- a/app-frontend/src/App.jsx
+++ b/app-frontend/src/App.jsx
@@ -31,21 +31,22 @@ function App() {
   }
 
   const addReview = (event) => {
-    event.preventDefault()
+    event.preventDefault();
+    setShowFeedback(false);
 
-    if(reviewText != ''){
+    if (reviewText !== '') {
       const newReview = {
         text: reviewText,
         sentiment: ""
-      }
+      };
 
       reviewService
-      .create(newReview)
-      .then(createdReview => {
-        setReviews(reviews.concat(createdReview))
-        setReviewText('')
-      })
-      setShowFeedback(true)
+        .create(newReview)
+        .then(createdReview => {
+          setReviews(reviews.concat(createdReview));
+          setReviewText('');
+          setShowFeedback(true);
+        });
     }
   }
 

--- a/app-frontend/src/Components/Feedback.jsx
+++ b/app-frontend/src/Components/Feedback.jsx
@@ -1,6 +1,13 @@
-import { useState} from 'react'
+import { useState, useEffect } from 'react';
+
 const Feedback = (props) => {
-    const [feedback, setFeedback] = useState(null)
+    const [feedback, setFeedback] = useState(null);
+
+    useEffect(() => {
+        if (props.showFeedback) {
+            setFeedback(null);
+        }
+    }, [props.showFeedback]);
 
     const handleFeedbackYes = () =>{
         setFeedback('yes')
@@ -21,7 +28,7 @@ const Feedback = (props) => {
                     (
                         <div class="feedback-buttons">
                             <button class="yes-button" onClick={()=>handleFeedbackYes()}>Yes 👍</button>
-                            <button type="submit" class="no-button" onClick={()=>handleFeedbackNo('no')}>No 👎</button>
+                            <button type="submit" class="no-button" onClick={()=>handleFeedbackNo()}>No 👎</button>
                         </div>
                     )
                     :


### PR DESCRIPTION
Feedback Reset and UI Consistency Improvements:

- Moved the logic to reset the feedback prompt (setShowFeedback(false)) to run at the start of the review submission (addReview function in App.jsx)
- Set setShowFeedback(true) only after a new review is successfully created, ensuring the feedback question resets and displays for each new review
- Added a useEffect in Feedback.jsx to reset the internal feedback state to null whenever showFeedback becomes true. This guarantees the feedback UI is always fresh when displayed
- Cleaned up the feedback button handlers in Feedback.jsx so the "No" button no longer receives an unused argument